### PR TITLE
Fix jest testing configuration

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,7 @@
 module.exports = {
     presets: [
       ['@babel/preset-env', {targets: {node: 'current'}}],
+      "@babel/preset-react",
       '@babel/preset-typescript',
     ],
   };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,7 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: 'ts-jest/presets/default-esm',
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '.(css|less|scss)$': 'identity-obj-proxy',
+    "^.+\\.svg$": "jest-svg-transformer"
+  }
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@babel/preset-react": "^7.23.3",
     "@testing-library/jest-dom": "^5.14.1",
-    "@testing-library/react": "^13.0.0",
+    "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.2.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^16.7.13",
@@ -17,10 +17,14 @@
     "typescript": "^5.3.3",
     "web-vitals": "^2.1.0"
   },
+  "overrides": {
+    "typescript": "^5.3.3"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "jest --transformIgnorePatterns",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -45,8 +49,9 @@
     "@babel/core": "^7.24.0",
     "@babel/preset-env": "^7.24.0",
     "@babel/preset-typescript": "^7.23.3",
-    "babel-jest": "^29.7.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
-    "ts-jest": "^29.1.2"
+    "jest-environment-jsdom": "^29.7.0",
+    "jest-svg-transformer": "^1.0.0"
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});
+describe('App', () => {
+  test('renders learn react link', () => {
+    render(<App />);
+    const linkElement = screen.getByText(/learn react/i);
+    expect(linkElement).toBeTruthy();
+  });
+})


### PR DESCRIPTION
Changes to package.json
- Added typescript override so `npm install` stops yelling about peer dependencies
- Added additional test for coverage. If you run `npm run test:coverage`, you will see what percentage of a component is covered by unit tests. The number will go down if you add props to a component until you add tests for each case. The goal is >75% coverage
- Added packages `identity-obj-proxy` and `jest-svg-transformer` so unit tests know what to do with SVGs and CSS
- Added the jsdom jest environment which is needed for `@testing-library/react`. [More info on the set up here](https://testing-library.com/docs/dom-testing-library/setup/)

Changes to jest.config.js
- Updated to use jsdom and add rules to handle SVGs and CSS